### PR TITLE
Change `or_where` to `or(where`

### DIFF
--- a/lib/identity/freshdesk/find_mailing.rb
+++ b/lib/identity/freshdesk/find_mailing.rb
@@ -19,7 +19,7 @@ module Identity
                              .where("mailing_test_cases.template LIKE ?", "%#{subject}%")
                              .select('DISTINCT mailings.id').pluck(:id)
 
-        Mailing.where(id: mailing_ids).or_where(subject: subject)
+        Mailing.where(id: mailing_ids).or(Mailing.where(subject: subject))
       end
     end
   end


### PR DESCRIPTION
👋 Hi! I'm excited to finally start using this Gem you were kind enough to write =)

I don't believe this `or_where` method exists, as it started throwing errors when I deployed the gem. I believe this syntax achieves the desired result though, at least according to [this guide](https://rubyplus.com/articles/3171-Rails-5-ActiveRecord-where-find-by-or-not-and-Eager-Loading)