### PR TITLE
Remove calls to functions which don't exist

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,8 +3,8 @@ PATH
   specs:
     identity-freshdesk (0.1.0)
       httpclient (~> 2.8.3)
-      rails (~> 5.2.2, >= 5.2.2.1)
-      sidekiq (>= 5.1.1)
+      rails (>= 5.2.2.1, > 5.2.2)
+      sidekiq (~> 6.0)
 
 GEM
   remote: https://rubygems.org/
@@ -52,13 +52,12 @@ GEM
       tzinfo (~> 1.1)
     arel (9.0.0)
     builder (3.2.3)
-    codecov (0.1.15)
+    codecov (0.2.12)
       json
       simplecov
-      url
     coderay (1.1.2)
     concurrent-ruby (1.1.5)
-    connection_pool (2.2.2)
+    connection_pool (2.2.3)
     crass (1.0.5)
     database_cleaner (1.7.0)
     diff-lcs (1.3)
@@ -76,7 +75,7 @@ GEM
     httpclient (2.8.3)
     i18n (1.6.0)
       concurrent-ruby (~> 1.0)
-    json (2.2.0)
+    json (2.3.1)
     loofah (2.3.1)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
@@ -85,11 +84,11 @@ GEM
     marcel (0.3.3)
       mimemagic (~> 0.3.2)
     method_source (0.9.2)
-    mimemagic (0.3.3)
-    mini_mime (1.0.1)
+    mimemagic (0.3.5)
+    mini_mime (1.0.2)
     mini_portile2 (2.4.0)
     minitest (5.11.3)
-    nio4r (2.3.1)
+    nio4r (2.5.4)
     nokogiri (1.10.5)
       mini_portile2 (~> 2.4.0)
     pg (1.1.4)
@@ -97,8 +96,6 @@ GEM
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
     rack (2.0.8)
-    rack-protection (2.0.5)
-      rack
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
     rails (5.2.3)
@@ -126,7 +123,7 @@ GEM
       rake (>= 0.8.7)
       thor (>= 0.19.0, < 2.0)
     rake (12.3.2)
-    redis (4.1.3)
+    redis (4.2.2)
     rspec-core (3.9.0)
       rspec-support (~> 3.9.0)
     rspec-expectations (3.9.0)
@@ -144,20 +141,18 @@ GEM
       rspec-mocks (~> 3.9.0)
       rspec-support (~> 3.9.0)
     rspec-support (3.9.0)
-    sidekiq (5.2.7)
-      connection_pool (~> 2.2, >= 2.2.2)
-      rack (>= 1.5.0)
-      rack-protection (>= 1.5.0)
-      redis (>= 3.3.5, < 5)
-    simplecov (0.17.1)
+    sidekiq (6.1.2)
+      connection_pool (>= 2.2.2)
+      rack (~> 2.0)
+      redis (>= 4.2.0)
+    simplecov (0.19.1)
       docile (~> 1.1)
-      json (>= 1.8, < 3)
-      simplecov-html (~> 0.10.0)
-    simplecov-html (0.10.2)
-    sprockets (3.7.2)
+      simplecov-html (~> 0.11)
+    simplecov-html (0.12.3)
+    sprockets (4.0.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
-    sprockets-rails (3.2.1)
+    sprockets-rails (3.2.2)
       actionpack (>= 4.0)
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
@@ -165,10 +160,9 @@ GEM
     thread_safe (0.3.6)
     tzinfo (1.2.5)
       thread_safe (~> 0.1)
-    url (0.3.2)
-    websocket-driver (0.7.0)
+    websocket-driver (0.7.3)
       websocket-extensions (>= 0.1.0)
-    websocket-extensions (0.1.3)
+    websocket-extensions (0.1.5)
 
 PLATFORMS
   ruby
@@ -185,4 +179,4 @@ DEPENDENCIES
   rspec-rails
 
 BUNDLED WITH
-   2.1.2
+   2.1.4

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,7 +4,7 @@ PATH
     identity-freshdesk (0.1.0)
       httpclient (~> 2.8.3)
       rails (~> 5.2.2, >= 5.2.2.1)
-      sidekiq (~> 5.1.1)
+      sidekiq (>= 5.1.1)
 
 GEM
   remote: https://rubygems.org/
@@ -126,7 +126,7 @@ GEM
       rake (>= 0.8.7)
       thor (>= 0.19.0, < 2.0)
     rake (12.3.2)
-    redis (4.1.1)
+    redis (4.1.3)
     rspec-core (3.9.0)
       rspec-support (~> 3.9.0)
     rspec-expectations (3.9.0)
@@ -144,9 +144,9 @@ GEM
       rspec-mocks (~> 3.9.0)
       rspec-support (~> 3.9.0)
     rspec-support (3.9.0)
-    sidekiq (5.1.3)
-      concurrent-ruby (~> 1.0)
-      connection_pool (~> 2.2, >= 2.2.0)
+    sidekiq (5.2.7)
+      connection_pool (~> 2.2, >= 2.2.2)
+      rack (>= 1.5.0)
       rack-protection (>= 1.5.0)
       redis (>= 3.3.5, < 5)
     simplecov (0.17.1)
@@ -185,4 +185,4 @@ DEPENDENCIES
   rspec-rails
 
 BUNDLED WITH
-   2.0.1
+   2.1.2

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ gem 'identity-freshdesk', git: "https://github.com/akcjademokracja/identity-fres
 
 ### Rules
 
-`options.default_mailing_from_email` is assumed to be the FD email.
+`options.from_email_address.email_blasts.default_value` is assumed to be the FD email.
 
 Below is an example set of rules you can use. Each rules is run for the ticket. If conditions are met, then the actions are run. After all rules are run, then results are pushed back to FD.
 

--- a/app/workers/identity/freshdesk/fetch_ticket_worker.rb
+++ b/app/workers/identity/freshdesk/fetch_ticket_worker.rb
@@ -30,7 +30,7 @@ module Identity
         # Do not process if the ticket e-mail wasn't sent to the "contact"
         # e-mail address
         if ticket['to_emails']
-          default_email = Settings.options.default_mailing_from_email
+          default_email = Settings.options.from_email_address.email_blasts.default_value
           return ticket['to_emails'].none? { |a| a.include? default_email }
         end
 

--- a/app/workers/identity/freshdesk/send_email_worker.rb
+++ b/app/workers/identity/freshdesk/send_email_worker.rb
@@ -4,7 +4,7 @@ module Identity
       include Sidekiq::Worker
 
       def perform(to, from, subject, body)
-        TransactionalMail.send_email(
+        Mailer::TransactionalMail.send_email(
           to: [to],
           from: "Freshdesk automation <#{from}>",
           subject: subject,

--- a/identity-freshdesk.gemspec
+++ b/identity-freshdesk.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'sidekiq', '~> 6.0'
   spec.add_dependency 'httpclient', '~> 2.8.3'
-  spec.add_dependency "rails", "~> 5.2.2", ">= 5.2.2.1"
+  spec.add_dependency "rails", "> 5.2.2", ">= 5.2.2.1"
 
   spec.add_development_dependency 'pry'
   spec.add_development_dependency 'database_cleaner'

--- a/lib/identity/freshdesk/find_mailing.rb
+++ b/lib/identity/freshdesk/find_mailing.rb
@@ -8,18 +8,18 @@ module Identity
           subject.gsub!(/^(odp|sv|re): /i, '')
           return mailings_by_subject subject
         else
-          return Mailing.none
+          return Mailings::Mailing.none
         end
       end
 
       def self.mailings_by_subject(subject)
         # By subject test variant used
         # An array of IDs matching the criteria, ex. [101, 102] or an empty array if nothing found
-        mailing_ids = Mailing.joins(:test_cases)
+        mailing_ids = Mailings::Mailing.joins(:test_cases)
                              .where("mailing_test_cases.template LIKE ?", "%#{subject}%")
                              .select('DISTINCT mailings.id').pluck(:id)
 
-        Mailing.where(id: mailing_ids).or(Mailing.where(subject: subject))
+        Mailings::Mailing.where(id: mailing_ids).or(Mailings::Mailing.where(subject: subject))
       end
     end
   end

--- a/lib/identity/freshdesk/rules.rb
+++ b/lib/identity/freshdesk/rules.rb
@@ -115,8 +115,7 @@ module Identity
       def tag_by_mailing!
         mailings = FindMailing.by_subject @ticket['subject']
         tags = mailings.map do |m|
-          m.name.split("-")[0].truncate(20, omission: "")
-           .to_slug.transliterate.to_s.downcase
+          m.name.split("-")[0].truncate(20, omission: "").downcase
         end
         @tags += tags.uniq
       end

--- a/lib/identity/freshdesk/rules.rb
+++ b/lib/identity/freshdesk/rules.rb
@@ -79,7 +79,7 @@ module Identity
       end
 
       def description_contains?(words)
-        from_email = Settings.options.default_mailing_from_email
+        from_email = Settings.options.from_email_address.email_blasts.default_value
         # a silly heuristic to get just reply to our email
         msg = @ticket["description_text"].split("<#{from_email}>").first
         return false if msg.nil?
@@ -123,7 +123,7 @@ module Identity
       def email!(e)
         # XXX add renders
         to = e['to']
-        from = Settings.options.default_mailing_from_email
+        from = Settings.options.from_email_address.email_blasts.default_value
         subject = render e['subject']
         body = render e['body']
 


### PR DESCRIPTION
Round two of testing for Uplift - `undefined method `to_slug' Did you mean?  to_s`.

As far as I understand it, a mailing name already *is* a string, certainly this is true in Uplift's configuration, so I'm suggesting we remove `to_slug.transliterate`. Ideally, I would also prefer to remove the split on the `-`, which seems quite particular to how you name your mailings, but I'll leave that discussion for another time!